### PR TITLE
Fix consumer bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ hs_err_pid*
 **/target/**
 /.idea/**
 **/*.iml
+*.orig

--- a/navigation-extender-runtime/pom.xml
+++ b/navigation-extender-runtime/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.foursoft.jaxb2</groupId>
@@ -28,11 +28,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/ExtendedUnmarshaller.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/ExtendedUnmarshaller.java
@@ -68,7 +68,7 @@ public class ExtendedUnmarshaller<R, I> {
     public ExtendedUnmarshaller(final Class<R> rootElement) throws JAXBException {
         this.rootElement = rootElement;
         final String packageName = rootElement.getPackage().getName();
-        final JAXBContext context = JaxbContextFactory.initializeContext(packageName);
+        final JAXBContext context = JAXBContextFactory.initializeContext(packageName);
         postProcessorRegistry = new ModelPostProcessorRegistry(packageName);
         unmarshaller = context.createUnmarshaller();
     }

--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/ExtendedUnmarshaller.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/ExtendedUnmarshaller.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,17 +48,14 @@ import java.util.function.Function;
  * <li>Registration and execution of custom {@link ModelPostProcessor}.</li>
  * </ul>
  * This is a wrapper arround an {@link Unmarshaller}.
- *
+ * <p>
  * The {@link ExtendedUnmarshaller} is required in order to correctly integrate
  * the two phase model post processing (see {@link ModelPostProcessor} into the
  * unmarshalling process.
  *
+ * @param <R> Type of the root element to unmarshall.
+ * @param <I> Type of elements that are identifiable.
  * @author becker
- *
- * @param <R>
- *            Type of the root element to unmarshall.
- * @param <I>
- *            Type of elements that are identifiable.
  */
 public class ExtendedUnmarshaller<R, I> {
 
@@ -69,8 +66,7 @@ public class ExtendedUnmarshaller<R, I> {
 
     public ExtendedUnmarshaller(final Class<R> rootElement) throws JAXBException {
         this.rootElement = rootElement;
-        final String packageName = rootElement.getPackage()
-                .getName();
+        final String packageName = rootElement.getPackage().getName();
         final JAXBContext context = JAXBContextFactory.initializeContext(packageName);
         postProcessorRegistry = new ModelPostProcessorRegistry(packageName);
         unmarshaller = context.createUnmarshaller();
@@ -81,7 +77,7 @@ public class ExtendedUnmarshaller<R, I> {
      * backreferences.
      *
      * @return Returns <tt>this</tt> for method chaining / fluent
-     *         initialization.
+     * initialization.
      */
     public ExtendedUnmarshaller<R, I> withBackReferences() {
         postProcessorRegistry.withFactory(ReflectiveAssociationPostProcessor::new);
@@ -100,12 +96,17 @@ public class ExtendedUnmarshaller<R, I> {
     }
 
     /**
-     * The jaxb unmarshaller has an event handler which is intercepted to provide the event for the consumer
+     * The jaxb unmarshaller has an event handler which is intercepted to provide the event for the consumer.
+     * This will reset the handler first to the default handler, and then add the given consumer to it
+     *
      * @param eventConsumer the consumer for the jaxb validation event
      * @return this for fluent API
      * @throws JAXBException if the unmarshalling goes wrong
      */
-    public ExtendedUnmarshaller<R, I> withEventLogging(final Consumer<ValidationEvent> eventConsumer) throws JAXBException {
+    public ExtendedUnmarshaller<R, I> withEventLogging(final Consumer<ValidationEvent> eventConsumer)
+            throws JAXBException {
+        unmarshaller.setEventHandler(null);
+
         final ValidationEventHandler eventHandler = unmarshaller.getEventHandler();
         unmarshaller.setEventHandler(event -> {
             eventConsumer.accept(event);
@@ -127,13 +128,12 @@ public class ExtendedUnmarshaller<R, I> {
      * the handling of all classes during the unmarshalling, even if the do not
      * have a shared superclass or interface.
      *
-     *
      * @param classOfIdentifiableElements the class of the identifiable element
-     * @param idMapper the mapper function to get the id of each element
+     * @param idMapper                    the mapper function to get the id of each element
      * @return this for fluent API
      */
     public ExtendedUnmarshaller<R, I> withIdMapper(final Class<I> classOfIdentifiableElements,
-            final Function<I, String> idMapper) {
+                                                   final Function<I, String> idMapper) {
         final IdLookupGeneratorPostProcessor<I> idLookupGenerator = new IdLookupGeneratorPostProcessor<>(
                 classOfIdentifiableElements, idMapper);
 
@@ -164,6 +164,7 @@ public class ExtendedUnmarshaller<R, I> {
 
     /**
      * Provides access to the internal jax-b unmarshaller for further configuration. Use with caution.
+     *
      * @return the internal jax-b unmarshaller
      */
     public Unmarshaller getUnmarshaller() {

--- a/navigation-extender-runtime/src/test/java/com/foursoft/xml/ExtendedUnmarshallerTest.java
+++ b/navigation-extender-runtime/src/test/java/com/foursoft/xml/ExtendedUnmarshallerTest.java
@@ -25,60 +25,153 @@
  */
 package com.foursoft.xml;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.foursoft.test.model.AbstractBase;
 import com.foursoft.test.model.ChildA;
 import com.foursoft.test.model.ChildB;
 import com.foursoft.test.model.Root;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.ValidationEvent;
+import javax.xml.bind.ValidationEventLocator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExtendedUnmarshallerTest {
 
-	@Test
-	public void unmarshallTest() throws JAXBException {
-		final ExtendedUnmarshaller<Root, AbstractBase> unmarshaller = new ExtendedUnmarshaller<Root, AbstractBase>(
-				Root.class).withBackReferences()
-						.withIdMapper(AbstractBase.class, AbstractBase::getXmlId);
+    @Test
+    public void consumerTest() throws JAXBException {
+        final List<ValidationEvent> result1 = new ArrayList<>();
+        final Consumer<ValidationEvent> consumer1 = o -> {
+            result1.add(o);
+        };
 
-		final JaxbModel<Root, AbstractBase> unmarshalledResult = unmarshaller.unmarshall(this.getClass()
-				.getResourceAsStream("/basic-test.xml"));
+        final ExtendedUnmarshaller<Root, AbstractBase> extUnmarshaller =
+                new ExtendedUnmarshaller<Root, AbstractBase>(Root.class)
+                        .withBackReferences()
+                        .withIdMapper(AbstractBase.class, AbstractBase::getXmlId)
+                        .withEventLogging(consumer1);
 
-		final Root rootElement = unmarshalledResult.getRootElement();
+        final Unmarshaller unmarshaller = extUnmarshaller.getUnmarshaller();
+        final ValidationEvent event = new ValidationEvent() {
+            @Override public int getSeverity() {
+                return 0;
+            }
 
-		assertThat(rootElement).isNotNull();
+            @Override public String getMessage() {
+                return null;
+            }
 
-		// Check Id Lookup initialized & parent associations
-		assertThat(unmarshalledResult.getIdLookup()
-				.findById(ChildB.class, "id_6")).isNotNull()
-						.isNotEmpty()
-						.get()
-						.returns("id_6", ChildB::getXmlId)
-						.returns(rootElement, ChildB::getRoot)
-						.returns("another value", ChildB::getXyz);
+            @Override public Throwable getLinkedException() {
+                return null;
+            }
 
-		final ChildA childAone = rootElement.getChildA()
-				.get(0);
-		final ChildA childATwo = rootElement.getChildA()
-				.get(1);
-		// Check Backref is working
-		assertThat(unmarshalledResult.getIdLookup()
-				.findById(ChildB.class, "id_6")
-				.get()
-				.getReverseChildA()).containsExactlyInAnyOrder(childAone);
+            @Override public ValidationEventLocator getLocator() {
+                return null;
+            }
+        };
+        unmarshaller.getEventHandler().handleEvent(event);
+        Assertions.assertEquals(1, result1.size());
 
-		assertThat(unmarshalledResult.getIdLookup()
-				.findById(ChildB.class, "id_7")
-				.get()
-				.getReverseChildA()).containsExactlyInAnyOrder(childAone, childATwo);
+    }
 
-		assertThat(unmarshalledResult.getIdLookup()
-				.findById(ChildB.class, "id_8")
-				.get()
-				.getReverseChildA()).containsExactlyInAnyOrder(childATwo);
+    /**
+     * if ExtendedUnmarshaller is reused and withEventLogging called multiple times,the old
+     * event consumer were not deleted!
+     *
+     * @throws JAXBException
+     */
+    @Test
+    public void multipleConsumerTest() throws JAXBException {
+        final List<ValidationEvent> result1 = new ArrayList<>();
+        final Consumer<ValidationEvent> consumer1 = o -> {
+            result1.add(o);
+        };
+        final List<ValidationEvent> result2 = new ArrayList<>();
+        final Consumer<ValidationEvent> consumer2 = o -> {
+            result2.add(o);
+        };
+        final ExtendedUnmarshaller<Root, AbstractBase> extUnmarshaller1 =
+                new ExtendedUnmarshaller<Root, AbstractBase>(Root.class)
+                        .withBackReferences()
+                        .withIdMapper(AbstractBase.class, AbstractBase::getXmlId)
+                        .withEventLogging(consumer1);
+        extUnmarshaller1.withEventLogging(consumer2);
 
-	}
+        final Unmarshaller unmarshaller = extUnmarshaller1.getUnmarshaller();
+        final ValidationEvent event = new ValidationEvent() {
+            @Override public int getSeverity() {
+                return 0;
+            }
+
+            @Override public String getMessage() {
+                return null;
+            }
+
+            @Override public Throwable getLinkedException() {
+                return null;
+            }
+
+            @Override public ValidationEventLocator getLocator() {
+                return null;
+            }
+        };
+        unmarshaller.getEventHandler().handleEvent(event);
+        Assertions.assertEquals(0, result1.size());
+        Assertions.assertEquals(1, result2.size());
+
+    }
+
+    @Test
+    public void unmarshallTest() throws JAXBException {
+        final ExtendedUnmarshaller<Root, AbstractBase> unmarshaller = new ExtendedUnmarshaller<Root, AbstractBase>(
+                Root.class).withBackReferences()
+                .withIdMapper(AbstractBase.class, AbstractBase::getXmlId);
+
+        final JaxbModel<Root, AbstractBase> unmarshalledResult = unmarshaller.unmarshall(getClass()
+                                                                                                 .getResourceAsStream(
+                                                                                                         "/basic-test" +
+                                                                                                                 ".xml"
+                                                                                                 ));
+
+        final Root rootElement = unmarshalledResult.getRootElement();
+
+        assertThat(rootElement).isNotNull();
+
+        // Check Id Lookup initialized & parent associations
+        assertThat(unmarshalledResult.getIdLookup()
+                           .findById(ChildB.class, "id_6")).isNotNull()
+                .isNotEmpty()
+                .get()
+                .returns("id_6", ChildB::getXmlId)
+                .returns(rootElement, ChildB::getRoot)
+                .returns("another value", ChildB::getXyz);
+
+        final ChildA childAone = rootElement.getChildA()
+                .get(0);
+        final ChildA childATwo = rootElement.getChildA()
+                .get(1);
+        // Check Backref is working
+        assertThat(unmarshalledResult.getIdLookup()
+                           .findById(ChildB.class, "id_6")
+                           .get()
+                           .getReverseChildA()).containsExactlyInAnyOrder(childAone);
+
+        assertThat(unmarshalledResult.getIdLookup()
+                           .findById(ChildB.class, "id_7")
+                           .get()
+                           .getReverseChildA()).containsExactlyInAnyOrder(childAone, childATwo);
+
+        assertThat(unmarshalledResult.getIdLookup()
+                           .findById(ChildB.class, "id_8")
+                           .get()
+                           .getReverseChildA()).containsExactlyInAnyOrder(childATwo);
+
+    }
 
 }

--- a/navigation-extender/pom.xml
+++ b/navigation-extender/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.foursoft.jaxb2</groupId>
@@ -49,11 +49,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.foursoft.jaxb2</groupId>
@@ -190,6 +190,23 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${license-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>${junit.jupiter.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>1.3.2</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Pull Request

- [ x] I have checked for similar PRs.
- [ x] I have read the [contributing guidelines](https://github.com/4Soft-de/jaxb-enhanced-navigation/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ x] Code
- [ x] Documentation
- [ ] Other: 

Closes: -

### Description
If the extended marshaller is reused (e.g. in threadlocal) multiple calls to withEventLogging() will not remove old registered consumers.
