### PR TITLE
Add DependaBot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Enable dependency updates for Maven
+  - package-ecosystem: "maven"
+    # Look for the pom.xml in the root folder
+    directory: "/"
+    schedule:
+      # Daily Updates (time can be set via. `time: "02:00"` under `interval`)
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+# Full reference: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/jaxb-enhanced-navigation/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ ] Code
- [ ] Documentation
- [x] Other: Dependencies

### Description

Adds DependaBot to keep Maven and GH Action dependencies up2date.