### PR TITLE
XMLWriter#writeToString with XMLMeta object

### DIFF
--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
@@ -155,6 +155,22 @@ public class XMLWriter<T> {
         }
     }
 
+    /**
+     * Write the JAXB model to a String. Allows Meta Data as like as comments to be passed with.
+     *
+     * @param container the jaxb model to deserialize into the given stream
+     * @param meta      additional meta information which should be added to output {@link XMLMeta}
+     * @return the model as xml string
+     */
+    public String writeToString(final T container, final XMLMeta meta) {
+        try (final StringWriter stringWriter = new StringWriter()) {
+            write(container, meta, stringWriter);
+            return stringWriter.toString();
+        } catch (final IOException e) {
+            throw new XMLIOException("Error serializing objects to XML", e);
+        }
+    }
+
     private void write(final T container, final XMLMeta meta, final Writer output) {
         final XMLOutputFactory xof = XMLOutputFactory.newFactory();
         try {

--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
@@ -113,6 +113,8 @@ public class XMLWriter<T> {
      * @param container    the jaxb model to deserialize into the given stream
      * @param outputStream the output to write to
      * @param comments     additional comments which should be added to output {@link Comments}
+     *
+     * @deprecated Use {@link #write(T, XMLMeta, OutputStream)} and {@link XMLMeta#setComments(Comments)} instead.
      */
     @Deprecated
     public void write(final T container, final Comments comments, final OutputStream outputStream) {
@@ -127,6 +129,8 @@ public class XMLWriter<T> {
      * @param container the jaxb model to deserialize into the given stream
      * @param comments  additional comments which should be added to output {@link Comments}
      * @return the model as xml string
+     *
+     * @deprecated Use {@link #writeToString(T, XMLMeta)} and {@link XMLMeta#setComments(Comments)} instead.
      */
     @Deprecated
     public String writeToString(final T container, final Comments comments) {

--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
@@ -136,12 +136,7 @@ public class XMLWriter<T> {
     public String writeToString(final T container, final Comments comments) {
         final XMLMeta meta = new XMLMeta();
         meta.setComments(comments);
-        try (final StringWriter stringWriter = new StringWriter()) {
-            write(container, meta, stringWriter);
-            return stringWriter.toString();
-        } catch (final Exception e) {
-            throw new XMLIOException("Error serializing objects to XML.", e);
-        }
+        return writeToString(container, meta);
     }
 
     /**
@@ -151,12 +146,9 @@ public class XMLWriter<T> {
      * @return the model as xml string
      */
     public String writeToString(final T container) {
-        try (final StringWriter stringWriter = new StringWriter()) {
-            write(container, stringWriter);
-            return stringWriter.toString();
-        } catch (final IOException e) {
-            throw new XMLIOException("Error serializing objects to XML", e);
-        }
+        final StringWriter stringWriter = new StringWriter();
+        write(container, stringWriter);
+        return stringWriter.toString();
     }
 
     /**
@@ -167,12 +159,9 @@ public class XMLWriter<T> {
      * @return the model as xml string
      */
     public String writeToString(final T container, final XMLMeta meta) {
-        try (final StringWriter stringWriter = new StringWriter()) {
-            write(container, meta, stringWriter);
-            return stringWriter.toString();
-        } catch (final IOException e) {
-            throw new XMLIOException("Error serializing objects to XML", e);
-        }
+        final StringWriter stringWriter = new StringWriter();
+        write(container, meta, stringWriter);
+        return stringWriter.toString();
     }
 
     private void write(final T container, final XMLMeta meta, final Writer output) {

--- a/navigation-extender-runtime/src/test/java/com/foursoft/xml/io/write/XMLWriterTest.java
+++ b/navigation-extender-runtime/src/test/java/com/foursoft/xml/io/write/XMLWriterTest.java
@@ -63,7 +63,9 @@ class XMLWriterTest {
         final Comments comments = new Comments();
         final String expectedComment = "Blafasel";
         comments.put(root.getChildA().get(0), expectedComment);
-        final String result = xmlWriter.writeToString(root, comments);
+        final XMLMeta xmlMeta = new XMLMeta();
+        xmlMeta.setComments(comments);
+        final String result = xmlWriter.writeToString(root, xmlMeta);
         assertFalse(validationEventCollector.hasEvents(), "Should produce no errors!");
         Assertions.assertThat(result).contains(expectedComment);
     }


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/jaxb-enhanced-navigation/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [x] Documentation
- [ ] Other: 

### Description

Added a new method to write a container to a String allowing `XMLMeta` data to be passed.

Also added deprecation notices to the docs and replaced usage of the deprecated method with the new one.