### PR TITLE
Initialize JaxbContext with the ClassLoader of this library

### DIFF
--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/ExtendedUnmarshaller.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/ExtendedUnmarshaller.java
@@ -83,7 +83,7 @@ public class ExtendedUnmarshaller<R, I> {
     public ExtendedUnmarshaller(final Class<R> rootElement) throws JAXBException {
         this.rootElement = rootElement;
         final String packageName = rootElement.getPackage().getName();
-        final JAXBContext context = JaxbContextFactory.initializeContext(packageName);
+        final JAXBContext context = JaxbContextFactory.initializeContext(packageName, this.getClass().getClassLoader());
         postProcessorRegistry = new ModelPostProcessorRegistry(packageName);
         unmarshaller = context.createUnmarshaller();
     }

--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/JaxbContextFactory.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/JaxbContextFactory.java
@@ -45,12 +45,12 @@ public final class JaxbContextFactory {
         throw new UnsupportedOperationException("JAXBContextFactory shall not be instantiated (static class");
     }
 
-    public static synchronized JAXBContext initializeContext(final String packageName) throws JAXBException {
+    public static synchronized JAXBContext initializeContext(final String packageName, final ClassLoader classLoader) throws JAXBException {
         JAXBContext context = jaxbContextCache.get(packageName);
 
         // not implemented with computeIfAbsent because .newInstance throws JAXBException
         if (context == null) {
-            context = JAXBContext.newInstance(packageName);
+            context = JAXBContext.newInstance(packageName, classLoader);
             jaxbContextCache.put(packageName, context);
         }
 

--- a/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
+++ b/navigation-extender-runtime/src/main/java/com/foursoft/xml/io/write/XMLWriter.java
@@ -64,7 +64,7 @@ public class XMLWriter<T> {
         this.baseType = baseType;
         try {
             final String packageName = this.baseType.getPackage().getName();
-            final JAXBContext jaxbContext = JaxbContextFactory.initializeContext(packageName);
+            final JAXBContext jaxbContext = JaxbContextFactory.initializeContext(packageName, NamespacePrefixMapperImpl.class.getClassLoader());
             marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");


### PR DESCRIPTION
## Pull Request

- [x ] I have checked for similar PRs.
- [x ] I have read the [contributing guidelines](https://github.com/4Soft-de/jaxb-enhanced-navigation/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x ] Code
- [ ] Documentation
- [ ] Other: 


### Description

When using an application server that brings its own JAXB-library there can be a problem with the class path.
In our case the example was with the OpenLiberty which has a JAXB 2.2 library. 
The NamespacePrefixMapperImpl was then loaded with the AppClassLoader with the JAXB 2.3 library but the JaxbContext with the ClassLoader of the OpenLiberty which was the 2.2 library. This caused that the setProperty of the NamespacePrefixMapper ran into an error.